### PR TITLE
Add support for x2 and potter

### DIFF
--- a/root/META-INF/com/google/android/update-binary
+++ b/root/META-INF/com/google/android/update-binary
@@ -26309,7 +26309,7 @@ case ${RO_PRODUCT_DEVICE} in
         FSTAB_LIST=fstab.bullhead
         unpack_bootimg_utils_arm64
         ;;
-    ether)
+    ether|x2|potter)
         BOOT_BLKDEV=$(${BUSYBOX} readlink -f /dev/block/bootdevice/by-name/boot)
         FSTAB_LIST='fstab.qcom'
         unpack_bootimg_utils_arm64


### PR DESCRIPTION
I reused ether's spot because they are the same layout

x2 = LeEco Le Max 2
potter = Moto G5+